### PR TITLE
[WIP]README データベース設計の記載１回目

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 |group_name|string|null: false, foreign_key: true, unique: true|
 
+### Association
+- has_many :users_groups
+- has_many :users, through: :users_groups
+
 ## users_groupsテーブル
 
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|user_name|string|null: false, foreign_key: true|
+|id|integer|null: false, foreign_key: true|
+|name|string|null: false, foreign_key: true|
 |email|string|null: false, unique: true|
 |pass|integer|null: false, foreign_key: true|
 
@@ -43,12 +43,13 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, foreign_key: true|
-|group_name|string|null: false, foreign_key: true, unique: true|
+|id|integer|null: false, foreign_key: true|
+|name|string|null: false, foreign_key: true, unique: true|
 
 ### groups-Association
 - has_many :users_groups
 - has_many :users, through: :users_groups
+- has_many :messages
 
 ## users_groupsテーブル
 
@@ -65,10 +66,13 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|message_id|integer|null: false, foreign_key: true|
+|id|integer|null: false, foreign_key: true|
 |body|text||
 |image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### messages-Association
 
 - belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ Things you may want to cover:
 |message_id|integer|null: false, foreign_key: true|
 |body|text||
 |image|string||
+
+### Association
+
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -30,4 +30,9 @@ Things you may want to cover:
 
 ## users_groupsテーブル
 
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
 ## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Things you may want to cover:
 |email|string|null: false, unique: true|
 |pass|integer|null: false, foreign_key: true|
 
+### Association
+- has_many :messages, through: :users_groups
 
 ## groupsテーブル
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## usersテーブル
+
+## groupsテーブル
+
+## users_groupsテーブル
+
+## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Things you may want to cover:
 
 ## groupsテーブル
 
+|Column|Type|Options|
+|------|----|-------|
+|group_id|integer|null: false, foreign_key: true|
+|group_name|string|null: false, foreign_key: true, unique: true|
+
 ## users_groupsテーブル
 
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |id|integer|null: false, foreign_key: true|
-|name|string|null: false, foreign_key: true|
+|name|string|null: false|
 |email|string|null: false, unique: true|
 |pass|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Things you may want to cover:
 
 ## usersテーブル
 
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|user_name|string|null: false, foreign_key: true|
+|email|string|null: false, unique: true|
+|pass|integer|null: false, foreign_key: true|
+
+
 ## groupsテーブル
 
 ## users_groupsテーブル

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Things you may want to cover:
 |pass|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :messages, through: :users_groups
+- has_many :messages
+- has_many :users_groups
+- has_many :groups, through:users_groups
+
 
 ## groupsテーブル
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Things you may want to cover:
 |email|string|null: false, unique: true|
 |pass|integer|null: false, foreign_key: true|
 
-### Association
+### users-Association
 - has_many :messages
 - has_many :users_groups
 - has_many :groups, through:users_groups
@@ -46,7 +46,7 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 |group_name|string|null: false, foreign_key: true, unique: true|
 
-### Association
+### groups-Association
 - has_many :users_groups
 - has_many :users, through: :users_groups
 
@@ -57,7 +57,7 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
-### Association
+### users_groups-Association
 - belongs_to :group
 - belongs_to :user
 
@@ -69,6 +69,6 @@ Things you may want to cover:
 |body|text||
 |image|string||
 
-### Association
+### messages-Association
 
 - belongs_to :user

--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ Things you may want to cover:
 - belongs_to :user
 
 ## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|message_id|integer|null: false, foreign_key: true|
+|body|text||
+|image|string||

--- a/README.md
+++ b/README.md
@@ -35,4 +35,8 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 
+### Association
+- belongs_to :group
+- belongs_to :user
+
 ## messagesテーブル


### PR DESCRIPTION
# WHAT
chat-spaceのデータベースの設計をREADMEに記載
テーブルは『users, groups, users-groups, messages』の４つ
また各テーブルに対応するアソシエーションを記載した
READMEに記載した段階で実装はしていない

# WHY
今後データベースの実装を始めるにあたり、機能の洗い出しになるとともにREADMEを見ることで当初の設計を振り返ることができるため記載した